### PR TITLE
Added a function to get Newgrounds session without prompting for login

### DIFF
--- a/ng_library.js
+++ b/ng_library.js
@@ -23,6 +23,14 @@ function ng_request_login() {
 	});
 }
 
+function ng_get_login() {
+	ngio.getValidSession(function () {
+		if (ngio.user) {
+			onLoggedIn();
+		}
+	});
+}
+
 function ng_cancel_login() {
 	ngio.cancelLoginRequest();
 }


### PR DESCRIPTION
I've added a new function `ng_get_login` that does the same as `ng_request_login` without opening the Newgrounds Password tab. 

This function can be used to get the Newgrounds session, well, without prompting for login.